### PR TITLE
Add HandleFunc method to base router

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ import (
 
 func main() {
 	rtr := icepop.NewUsernameRouter()
-	rtr.Handle(
+	rtr.HandleFunc(
 		// the expected username
 		"itshotoutside", 
 		// The handler to be used.
-		icepop.NewSessionHandlerFrom(func(s ssh.Session) {
+		func(s ssh.Session) {
 			wish.Println(s, "I love Ice pops!")
 			s.Exit(0)
 			s.Close()
@@ -90,12 +90,12 @@ import (
 
 func main() {
 	rtr := icepop.NewCommandRouter()
-	rtr.Handle(
+	rtr.HandleFunc(
 		"favorite-flavor",
-		icepop.NewSessionHandlerFrom(func(s ssh.Session) {
+		func(s ssh.Session) {
 			io.WriteString(s, "I like cherry!")
 			s.Exit(0)
-		}))
+		})
 
 	ssh.Handle(rtr.Handler())
 

--- a/base_router.go
+++ b/base_router.go
@@ -1,6 +1,10 @@
 package icepop
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/gliderlabs/ssh"
+)
 
 // Router is basic Router structure. It can be embedded in custom
 // routers to provide easy access to the Handle method. Custom
@@ -17,6 +21,16 @@ func (r *Router) Handle(path string, sh SessionHandler) {
 	}
 
 	r.routes[path] = sh
+}
+
+// HandleFunc binds a ssh.Handler to a SessionHandler and binds it to path.
+// If a handler already exists, this panics.
+func (r *Router) HandleFunc(path string, hf ssh.Handler) {
+	if _, exists := r.routes[path]; exists {
+		panic("Attempted to rebind a pre-existing handler: %s")
+	}
+
+	r.routes[path] = NewSessionHandlerFrom(hf)
 }
 
 // HandlerFor returns the handler for the given path value, or an error

--- a/examples/minimal-gliderlabs-demo/main.go
+++ b/examples/minimal-gliderlabs-demo/main.go
@@ -10,12 +10,12 @@ import (
 
 func main() {
 	rtr := icepop.NewCommandRouter()
-	rtr.Handle(
+	rtr.HandleFunc(
 		"favorite-flavor",
-		icepop.NewSessionHandlerFrom(func(s ssh.Session) {
+		func(s ssh.Session) {
 			io.WriteString(s, "I like cherry!")
 			s.Exit(0)
-		}))
+		})
 
 	ssh.Handle(rtr.Handler())
 


### PR DESCRIPTION
Adding HandleFunc as a method on the base router, which removes the immediate need to use `NewSessionHandlerFrom` to convert an `ssh.Handler` before binding it to a path.

Signed-off-by: Jose R. Gonzalez <jose@flutes.dev>